### PR TITLE
Fix Github/Shield Links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,10 @@ Commit messages should be clear, as we additionally recommend (but don't require
 
 [asdf]: https://asdf-vm.com/
 [asdf-setup]: https://asdf-vm.com/guide/getting-started.html
-[bugs]: https://github.com/QMalcolm/ex_ttrpg_dev/issues/new?assignees=&labels=&template=bug_report.md
+[bugs]: https://github.com/TTRPG-Dev/ex_ttrpg_dev/issues/new?assignees=&labels=&template=bug_report.md
 [conduct]: CODE_OF_CONDUCT.md
 [egghead]: https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github
 [elixir-install]: https://elixir-lang.org/install.html
-[feature-request]: https://github.com/QMalcolm/ex_ttrpg_dev/issues/new?assignees=&labels=&template=feature_request.md
-[new-pr]: https://github.com/QMalcolm/ex_ttrpg_dev/compare
+[feature-request]: https://github.com/TTRPG-Dev/ex_ttrpg_dev/issues/new?assignees=&labels=&template=feature_request.md
+[new-pr]: https://github.com/TTRPG-Dev/ex_ttrpg_dev/compare
 [tool-versions]: .tool-versions

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ExTTRPGDev
 
-![GitHub watchers](https://img.shields.io/github/watchers/qmalcolm/ex_ttrpg_dev?style=social)
-![GitHub forks](https://img.shields.io/github/forks/qmalcolm/ex_ttrpg_dev?style=social)
-![GitHub Repo stars](https://img.shields.io/github/stars/qmalcolm/ex_ttrpg_dev?style=social)
+![GitHub watchers](https://img.shields.io/github/watchers/ttrpg-dev/ex_ttrpg_dev?style=social)
+![GitHub forks](https://img.shields.io/github/forks/ttrpg-dev/ex_ttrpg_dev?style=social)
+![GitHub Repo stars](https://img.shields.io/github/stars/ttrpg-dev/ex_ttrpg_dev?style=social)
 
 [![Hex.pm](https://img.shields.io/hexpm/v/ex_ttrpg_dev)](https://hex.pm/packages/ex_ttrpg_dev)
 [![Hex.pm](https://img.shields.io/hexpm/dt/ex_ttrpg_dev)](https://hex.pm/packages/ex_ttrpg_dev)
 [![Documentation](https://img.shields.io/badge/documentation-gray)](https://hexdocs.pm/ex_ttrpg_dev)
-[![Hex.pm](https://img.shields.io/hexpm/l/ex_ttrpg_dev)](https://github.com/QMalcolm/ex_ttrpg_dev/blob/main/LICENSE)
+[![Hex.pm](https://img.shields.io/hexpm/l/ex_ttrpg_dev)](https://github.com/TTRPG-Dev/ex_ttrpg_dev/blob/main/LICENSE)
 
 ExTTRPGDev is a general tabletop role-playing game utility written in Elixir.
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule ExTTRPGDev.MixProject do
       description: description(),
       package: package(),
       name: "ExTTRPGDev",
-      source_url: "https://github.com/QMalcolm/ex_ttrpg_dev"
+      source_url: "https://github.com/TTRPG-Dev/ex_ttrpg_dev"
     ]
   end
 
@@ -46,7 +46,7 @@ defmodule ExTTRPGDev.MixProject do
   defp package() do
     [
       licenses: ["GPL-3.0-only"],
-      links: %{"GitHub" => "https://github.com/QMalcolm/ex_ttrpg_dev"}
+      links: %{"GitHub" => "https://github.com/TTRPG-Dev/ex_ttrpg_dev"}
     ]
   end
 end


### PR DESCRIPTION
## Is there an associated github issue?

No

## What is this PR changing?

We recently renamed the project and moved ownership from a personal
github account to an organization. As part of that we updated
"ex_rpg" to "ex_ttrpg_dev" and "ExRPG" to "ExTTRPGDev" throughout
the codebase. However, I forgot to do things like change "qmalcolm"
to "TTRPG-Dev".