### PR TITLE
Enable `ex_ttrpg_dev roll` to handle multiple dice specs

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -5,6 +5,7 @@ defmodule ExTTRPGDev.CLI do
   alias ExTTRPGDev.RuleSystems.Abilities
   alias ExTTRPGDev.RuleSystems.Languages
   alias ExTTRPGDev.RuleSystems.Skills
+  alias ExTTRPGDev.CustomParsers
 
   @moduledoc """
   The CLI for the project
@@ -30,7 +31,7 @@ defmodule ExTTRPGDev.CLI do
                 help:
                   "Dice in the format of xdy wherein x is the number of dice, y is the number of sides the dice should have",
                 required: true,
-                parser: :string
+                parser: &CustomParsers.dice_parser(&1)
               ]
             ]
           ],
@@ -144,9 +145,10 @@ defmodule ExTTRPGDev.CLI do
     end
   end
 
-  def handle_roll(%Optimus.ParseResult{args: %{dice: dice_str}}) do
-    Dice.roll(dice_str)
-    |> IO.inspect(label: "Results")
+  def handle_roll(%Optimus.ParseResult{args: %{dice: dice}}) do
+    dice
+    |> Enum.map(fn dice_spec -> {dice_spec, Dice.roll(dice_spec)} end)
+    |> Enum.each(fn {dice_spec, results} -> IO.inspect(results, label: dice_spec) end)
   end
 
   def handle_system_subcommands([command | subcommands], %Optimus.ParseResult{

--- a/lib/custom_parsers.ex
+++ b/lib/custom_parsers.ex
@@ -1,0 +1,20 @@
+defmodule ExTTRPGDev.CustomParsers do
+  @moduledoc """
+  Custom parsers to be used with Optimus args :parse
+  """
+
+  @doc """
+  Parses a string of dice specifications seperated by commas
+
+  ## Examples
+
+      iex> ExTTRPGDev.CustomParsers.dice_parser("3d4, 1d10,2d20")
+      {:ok, ["3d4", "1d10", "2d20"]}
+  """
+  def dice_parser(arg) when is_bitstring(arg) do
+    arg
+    |> String.split(",")
+    |> Enum.map(&String.trim(&1))
+    |> Kernel.then(fn result -> {:ok, result} end)
+  end
+end

--- a/test/custom_parsers_test.exs
+++ b/test/custom_parsers_test.exs
@@ -1,0 +1,5 @@
+defmodule ExTTRPGDevTest.CustomParsers do
+  use ExUnit.Case
+
+  doctest ExTTRPGDev.CustomParsers
+end


### PR DESCRIPTION
## Is there an associated github issue?
No

## What is this PR changing?

Previously, only one dice spec could be given, i.e. `ex_ttrpg_dev roll 3d4`. However, now multiple dice specs can be given in a single invocation. That is, one can now do something like
```
$ ./ex_ttrpg_dev roll 10d10,10d12,10d20
10d10: [5, 3, 8, 4, 10, 3, 9, 2, 7, 4]
10d12: [9, 3, 3, 4, 11, 12, 12, 3, 6, 12]
10d20: [7, 3, 7, 4, 6, 1, 16, 3, 16, 6]
```