### PR TITLE
Move logic for multi rolls

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -147,7 +147,7 @@ defmodule ExTTRPGDev.CLI do
 
   def handle_roll(%Optimus.ParseResult{args: %{dice: dice}}) do
     dice
-    |> Enum.map(fn dice_spec -> {dice_spec, Dice.roll(dice_spec)} end)
+    |> Dice.multi_roll!()
     |> Enum.each(fn {dice_spec, results} -> IO.inspect(results, label: dice_spec) end)
   end
 

--- a/lib/dice.ex
+++ b/lib/dice.ex
@@ -86,6 +86,26 @@ defmodule ExTTRPGDev.Dice do
   end
 
   @doc """
+  Roll multiple roll specs
+
+  Returns: List of tuples, the first value being the roll spec, the second being the results
+
+  ## Examples
+      # Although not necessary, let's seed the random algorithm
+      iex> :rand.seed(:exsplus, 1337)
+      iex> ExTTRPGDev.Dice.multi_roll!(["3d4", "4d8", "2d20"])
+      [{"3d4", [4, 4, 1]}, {"4d8", [1, 3, 5, 6]}, {"2d20", [5, 12]}]
+
+      iex> ExTTRPGDev.Dice.multi_roll!(["bad_spec", "oh_no!", "3d4"])
+      ** (RuntimeError) Improper dice format. Dice must be given in xdy where x and y are both integers
+
+  """
+  def multi_roll!(roll_specs) when is_list(roll_specs) do
+    roll_specs
+    |> Enum.map(fn roll_spec -> {roll_spec, roll(roll_spec)} end)
+  end
+
+  @doc """
   Rolls a die with the number of sides given in the input
 
   Returns: the rolled number

--- a/lib/dice.ex
+++ b/lib/dice.ex
@@ -62,27 +62,27 @@ defmodule ExTTRPGDev.Dice do
       iex> ExTTRPGDev.Dice.roll(3, 8)
       [4, 8, 5]
 
-  """
-  def roll(number_of_dice, dice_sides) do
-    Enum.map(1..number_of_dice, fn _ -> roll_d(dice_sides) end)
-  end
-
-  @doc """
-  Roll dice defined by the input string
-
-  Returns: List of die roll results
-
-  ## Examples
-
-      # Although not necessary, let's seed the random algorithm
       iex> :rand.seed(:exsplus, 1337)
-      iex> ExTTRPGDev.Dice.roll("3d4")
-      [4, 4, 1]
+      iex> ExTTRPGDev.Dice.roll({3, 8})
+      [4, 8, 5]
+
+      iex> :rand.seed(:exsplus, 1337)
+      iex> ExTTRPGDev.Dice.roll("3d8")
+      [4, 8, 5]
+
+      iex> ExTTRPGDev.Dice.roll("bad_input")
+      ** (RuntimeError) Improper dice format. Dice must be given in xdy where x and y are both integers
 
   """
   def roll(str) when is_bitstring(str) do
     {number_of_dice, sides} = parse_roll_spec!(str)
     roll(number_of_dice, sides)
+  end
+
+  def roll({number_of_dice, sides}), do: roll(number_of_dice, sides)
+
+  def roll(number_of_dice, dice_sides) do
+    Enum.map(1..number_of_dice, fn _ -> roll_d(dice_sides) end)
   end
 
   @doc """
@@ -95,6 +95,10 @@ defmodule ExTTRPGDev.Dice do
       iex> :rand.seed(:exsplus, 1337)
       iex> ExTTRPGDev.Dice.multi_roll!(["3d4", "4d8", "2d20"])
       [{"3d4", [4, 4, 1]}, {"4d8", [1, 3, 5, 6]}, {"2d20", [5, 12]}]
+
+      iex> :rand.seed(:exsplus, 1337)
+      iex> ExTTRPGDev.Dice.multi_roll!([{3, 4}, {4, 8}, {2, 20}])
+      [{{3, 4}, [4, 4, 1]}, {{4, 8}, [1, 3, 5, 6]}, {{2, 20}, [5, 12]}]
 
       iex> ExTTRPGDev.Dice.multi_roll!(["bad_spec", "oh_no!", "3d4"])
       ** (RuntimeError) Improper dice format. Dice must be given in xdy where x and y are both integers

--- a/lib/dice.ex
+++ b/lib/dice.ex
@@ -28,6 +28,29 @@ defmodule ExTTRPGDev.Dice do
   end
 
   @doc """
+  Tries to parse a given dice spec string into it's component parts
+
+  Returns: a tuple where the first item is the number of times to roll the die and the second indicates the  number or sides the die has
+
+  ## Examples
+
+      iex> ExTTRPGDev.Dice.parse_roll_spec!("3d4")
+      {3, 4}
+
+      iex> ExTTRPGDev.Dice.parse_roll_spec!("3")
+      ** (RuntimeError) Improper dice format. Dice must be given in xdy where x and y are both integers
+
+  """
+
+  def parse_roll_spec!(roll_spec) when is_bitstring(roll_spec) do
+    roll_spec
+    |> validate_dice_str()
+    |> String.split("d")
+    |> Enum.map(fn x -> String.to_integer(x) end)
+    |> List.to_tuple()
+  end
+
+  @doc """
   Rolls the a number of multisided dice
 
   Returns: List of die roll results
@@ -58,12 +81,7 @@ defmodule ExTTRPGDev.Dice do
 
   """
   def roll(str) when is_bitstring(str) do
-    [number_of_dice, sides] =
-      str
-      |> validate_dice_str()
-      |> String.split("d")
-      |> Enum.map(fn x -> String.to_integer(x) end)
-
+    {number_of_dice, sides} = parse_roll_spec!(str)
     roll(number_of_dice, sides)
   end
 


### PR DESCRIPTION
## Is there an associated github issue?

No

## What is this PR changing?

The logic for handling multiple dice roll specs was living in the CLI. As this logic seems relevant outside of CLI usage, it felt apt to abstract it elsewhere.