### PR TITLE
Ensure CLI results for rolling dice are printed as integers

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -148,7 +148,9 @@ defmodule ExTTRPGDev.CLI do
   def handle_roll(%Optimus.ParseResult{args: %{dice: dice}}) do
     dice
     |> Dice.multi_roll!()
-    |> Enum.each(fn {dice_spec, results} -> IO.inspect(results, label: dice_spec) end)
+    |> Enum.each(fn {dice_spec, results} ->
+      IO.inspect(results, label: dice_spec, charlists: :as_lists)
+    end)
   end
 
   def handle_system_subcommands([command | subcommands], %Optimus.ParseResult{


### PR DESCRIPTION
## Is there an associated github issue?
resolves #26

## What is this PR changing?

`IO.inspect` by default treats lists of integers as `charlists`. This means certain integer combinations result in the list being printed as `charlist`. This was rather confusing, as getting `~c"\a\n"` when rolling `2d10` doesn't make much sense (`~c"\a\n"` == `[7, 10]`). To force `IO.inspect` to read the list as a list of integers, we had to pass `charlists: :as_lists` in the opts of the function.